### PR TITLE
Small changes to filepaths to handle different access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ reports/.DS_Store
 
 #all tmp folders
 */tmp/*
+
+# Local only folders
+data_local/*

--- a/availability_checks/HLS_inventory.Rmd
+++ b/availability_checks/HLS_inventory.Rmd
@@ -36,7 +36,15 @@ Get and print collection information for HLS-L[andsat]:
 ```{r}
 hlsl_collection <- httr::GET(hlsl_col_url) %>% 
   httr::content()
-
+if(hlsl_collection$status %in% c(404, 500)) {
+  stop(sprintf(
+    "You weren't able to access to the HLS collection URL. 
+    Troubleshoot why before continuing. 
+    Workflow may have changed since this code was written.
+    
+    \nThe URL returned this error:\n %s: %s", 
+    hlsl_collection$status, hlsl_collection$errors))
+}
 hlsl_collection <- hlsl_collection %>% 
   jsonlite::toJSON(auto_unbox = TRUE) %>% 
   jsonlite::fromJSON()
@@ -69,7 +77,15 @@ hlss_collection$extent %>%
 Enter query terms to get info from STAC:
 
 ```{r}
-dumpdir = '~/OneDrive - Colostate/Superior/data/inventory/'
+dumpdir = 'data/inventory/'
+# Change how the directory is handled if you do not have access to the
+# symlink checked into the repo as `data`
+if(!file.info(dirname(dumpdir))$isdir) {
+  # If `data` is not a folder but rather a file, then you don't have
+  # access to that symlink directory and need to save your data elsewhere.
+  dumpdir = gsub('data', 'data_local', dumpdir)
+  if(!dir.exists(dumpdir)) dir.create(dumpdir, recursive=TRUE)
+}
 
 colls <- list("HLSS30.v2.0", "HLSL30.v2.0")
 

--- a/availability_checks/landsat_availability.Rmd
+++ b/availability_checks/landsat_availability.Rmd
@@ -72,7 +72,7 @@ l4 = ee.ImageCollection('LANDSAT/LT04/C02/T1_L2') \
 
 ls = ee.ImageCollection(l4.merge(l5).merge(l7).merge(l8).merge(l8))
 
-aoi = ee.FeatureCollection('projects/ee-ross-superior/assets/sup_pl_bl_small_aoi')
+aoi = ee.FeatureCollection('projects/ee-ross-superior/assets/superior_final_aoi')
 
 ls = ls.filterBounds(aoi)
 ```
@@ -293,7 +293,15 @@ alldata = map_dfr(filelist, read_file)
 
 alldata = alldata %>% rename(first_wrs = wrs)
 
-datadir = 'data/inventory'
+datadir = 'data/inventory/'
+# Change how the directory is handled if you do not have access to the
+# symlink checked into the repo as `data`
+if(!file.info(dirname(datadir))$isdir) {
+  # If `data` is not a folder but rather a file, then you don't have
+  # access to that symlink directory and need to save your data elsewhere.
+  datadir = gsub('data', 'data_local', datadir)
+  dir.create(datadir, recursive=TRUE)
+}
 write.csv(alldata, file.path(datadir, 'superior_ls_inventory.csv'), row.names = F)
 ```
 

--- a/availability_checks/landsat_availability.Rmd
+++ b/availability_checks/landsat_availability.Rmd
@@ -300,7 +300,7 @@ if(!file.info(dirname(datadir))$isdir) {
   # If `data` is not a folder but rather a file, then you don't have
   # access to that symlink directory and need to save your data elsewhere.
   datadir = gsub('data', 'data_local', datadir)
-  dir.create(datadir, recursive=TRUE)
+  if(!dir.exists(datadir)) dir.create(datadir, recursive=TRUE)
 }
 write.csv(alldata, file.path(datadir, 'superior_ls_inventory.csv'), row.names = F)
 ```

--- a/availability_checks/landsat_availability.Rmd
+++ b/availability_checks/landsat_availability.Rmd
@@ -42,7 +42,7 @@ In the terminal in your Rstudio, authenticate your GEE login information. Do thi
 
 `earthengine authenticate`
 
-This will open a browser for you to login using your Google account associated with your EE login. If this fails and says that gcloud is not installed or recognized, make sure you're using a zsh terminal by clicking the dropdown next to 'Terminal 1', clicking properties, choosing 'New Terminal Opens With' zsh. For whatever reason (at least on a MacOS M1), a bash terminal will not execute the authentication process correctly. Additionally, there are commands (ee.Authenticate) in the Python GEE API, however it does not work in an .Rmd or .Qmd file code chunk.
+This will open a browser for you to login using your Google account associated with your EE login. If this fails and says that gcloud is not installed or recognized, make sure you're using a zsh terminal by clicking the dropdown next to 'Terminal 1', clicking properties, choosing 'New Terminal Opens With' zsh. For whatever reason (at least on a MacOS M1), a bash terminal will not execute the authentication process correctly. Additionally, there are commands (ee.Authenticate) in the Python GEE API, however it does not work in an .Rmd or .Qmd file code chunk. You may have success running `ee.Authenticate()` in a different terminal that is running Python outside of RStudio. Then, you should be able to return to this Rmd and continue on with the next step.
 
 Now we can initiate our EE session:
 

--- a/availability_checks/modis_availability.Rmd
+++ b/availability_checks/modis_availability.Rmd
@@ -57,7 +57,7 @@ ee.Initialize()
 aqua = ee.ImageCollection('MODIS/061/MYD09GA')
 terra = ee.ImageCollection("MODIS/061/MOD09GA")
 
-aoi = ee.FeatureCollection('projects/ee-ross-superior/assets/sup_pl_bl_small_aoi')
+aoi = ee.FeatureCollection('projects/ee-ross-superior/assets/superior_final_aoi')
 ```
 
 ## Cacluate AOI area

--- a/availability_checks/modis_availability.Rmd
+++ b/availability_checks/modis_availability.Rmd
@@ -325,6 +325,14 @@ read_file = function(file) {
 alldata = map_dfr(filelist, read_file)
 
 datadir = 'data/inventory'
+# Change how the directory is handled if you do not have access to the
+# symlink checked into the repo as `data`
+if(!file.info(dirname(datadir))$isdir) {
+  # If `data` is not a folder but rather a file, then you don't have
+  # access to that symlink directory and need to save your data elsewhere.
+  datadir = gsub('data', 'data_local', datadir)
+  dir.create(datadir, recursive=TRUE)
+}
 write.csv(alldata, file.path(datadir, 'superior_modis_inventory.csv'), row.names = F)
 ```
 

--- a/availability_checks/modis_availability.Rmd
+++ b/availability_checks/modis_availability.Rmd
@@ -331,7 +331,7 @@ if(!file.info(dirname(datadir))$isdir) {
   # If `data` is not a folder but rather a file, then you don't have
   # access to that symlink directory and need to save your data elsewhere.
   datadir = gsub('data', 'data_local', datadir)
-  dir.create(datadir, recursive=TRUE)
+  if(!dir.exists(datadir)) dir.create(datadir, recursive=TRUE)
 }
 write.csv(alldata, file.path(datadir, 'superior_modis_inventory.csv'), row.names = F)
 ```

--- a/reports/2023-01_RSDataSummary.Rmd
+++ b/reports/2023-01_RSDataSummary.Rmd
@@ -11,7 +11,18 @@ output:
 knitr::opts_chunk$set(warning = FALSE, message = FALSE) 
 
 library(tidyverse)
-datadir = '~/Documents/GitHub/Superior-Plume-Bloom/data/inventory/'
+
+# This data inventory folder is created by code in `availability_checks/landsat_availability.Rmd`
+# and `availability_checks/modis_availability.Rmd`. Start there if you don't have any files in
+# `data/inventory`
+datadir = 'data/inventory'
+# Change how the directory is handled if you do not have access to the
+# symlink checked into the repo as `data`
+if(!file.info(dirname(datadir))$isdir) {
+  # If `data` is not a folder but rather a file, then you don't have
+  # access to that symlink directory and need to save your data elsewhere.
+  datadir = gsub('data', 'data_local', datadir)
+}
 
 ```
 
@@ -87,18 +98,30 @@ modis = read.csv(file.path(datadir, 'superior_modis_inventory.csv')) %>%
          date = as.Date(system.index, format = '%Y_%m_%d'))
 
 # filter and approximate coverage, where we assume tiles are completely in AOI and are equally weighted.
-hls = read.csv(file.path(datadir, 'superior_hls_all_requests.csv'))
-hls = unique(hls) #for whatever reason, there are a bunch of dupes in here
-hls = hls %>%   
-  filter(tile %in% c('15TWN', '15TXN', '15TYM', '15TWM', '15TXM', '15TYM') & #filter for desired 6 tiles
-    grepl('jpg', Asset_Link)) %>% #for the 'image' request
-  mutate(sat = 'HLS',
-         date = as.Date(as.POSIXct(substr(Datetime, 1, nchar(Datetime)-6), format = '%Y-%m-%dT%H:%M:%S', tz = 'UTC')),
-         p_area = (1/6)*((100-Cloud_Cover)/100)) %>% 
-  group_by(date, Collection, sat) %>% 
-  summarize(p_area = sum(p_area))
+hls_file = file.path(datadir, 'superior_hls_all_requests.csv')
+if(file.exists(hls_file)) {
+  hls = read.csv(hls_file)
+  hls = unique(hls) #for whatever reason, there are a bunch of dupes in here
+  hls = hls %>%   
+    filter(tile %in% c('15TWN', '15TXN', '15TYM', '15TWM', '15TXM', '15TYM') & #filter for desired 6 tiles
+             grepl('jpg', Asset_Link)) %>% #for the 'image' request
+    mutate(sat = 'HLS',
+           date = as.Date(as.POSIXct(substr(Datetime, 1, nchar(Datetime)-6), format = '%Y-%m-%dT%H:%M:%S', tz = 'UTC')),
+           p_area = (1/6)*((100-Cloud_Cover)/100)) %>% 
+    group_by(date, Collection, sat) %>% 
+    summarize(p_area = sum(p_area))
+} else {
+  # If the file doesn't exist, create an empty tibble and tell the user
+  message(sprintf('The HLS file (`%s`) does not exist. Continuing, but no HLS data will be included.', hls_file))
+  hls = tibble()
+}
 
-sats = full_join(ls, modis) %>% full_join(., hls) %>% 
+
+sats = full_join(ls, modis) %>% {
+  if(nrow(hls) > 0) 
+    full_join(., hls) 
+  else .
+} %>% 
   mutate(year = as.numeric(format(date, '%Y')),
          week = as.numeric(format(date, '%W')),
          month = as.numeric(format(date, '%m'))) %>% 


### PR DESCRIPTION
I can now knit the `reports/2023-01_RSDataSummary.Rmd` (it just doesn't have HLS data)! This PR includes some changes I had to make to get there. 

This does a few things but here are the big ones:

1. Updates the directory used to store data downloaded from Drive to not be the symlink if you don't have access
2. Handy empty HLS data due to not having access to download via the `HLS_inventory.Rmd`. 