### PR TITLE
added export of images to assets

### DIFF
--- a/eePlumB/Z_PrepAOI/validationSet_L457.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L457.js
@@ -1,0 +1,207 @@
+// This script creates the validation collection for eePlumB 
+// for Landsat 4, 5, 7 at Lake Superior
+// written by B. Steele
+// last modified 2020-03-14
+
+var aoi1 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_1');
+var aoi2 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_2');
+var aoi3 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_3');
+var aoi4 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_4');
+var aoi5 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_5');
+var aoi6 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_6');
+var aoi7 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_7');
+var aoi8 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_8');
+var aoi9 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_9');
+var aoi10 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_10');
+var aoi11 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_11');
+var aoi12 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_12');
+var aoi13 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_13');
+var aoi14 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_14');
+var aoi15 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_15');
+var aoi16 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_16');
+
+//------------------------------------//
+// DATES FOR USER VALIDATION ------------//
+//-------------------------------------//
+var date0 = '1984-05-04';
+var date1 = '1984-05-20';
+var date2 = '1987-08-17';
+var date3 = '1990-07-24';
+var date4 = '2004-06-28';
+var date5 = '2002-10-05';
+var date6 = '1995-05-19';
+var date7 = '2020-05-31';
+
+// notes from b's noodling around - to see these yourself, uncomment
+// the last two blocks of code and fill in dates on line 124, aoi on 129,
+// and optionally, aoi id on 130
+//date0, aoi1 -- dark sediment, deep sediment, unmasked cloud top r
+//date0, aoi4 -- open water, unmasked clouds
+//date1, aoi1 -- pervasive sediment along shore, unmasked clouds top l
+//date1, aoi9 -- cloud artifacts, open water
+//date2, aoi12 -- sedmient along shore of island, unmasked clouds
+//date2, aoi8 -- sedmient on N side of island, unmasked clouds
+//date3, aoi10 -- stringy sediment between shore and island, open water
+//date4, aoi2 - cloud artifacts (dark areas adjacent to masked clouds, brown/green sedmient, unmasked clouds
+//date4, aoi6 - open water, deep plumes, cloud artifacts, unmasked clouds
+//date5, aoi5 -- brilliant sediment, open water
+//date5, aoi15 -- open water
+//date6, aoi9 -- knife river sediment, open water, unmasked clouds, shoreline artifacts (two harbors)
+//date7, aoi4 -- deep sediment, open water, near-shore artifacts (near canal park)
+//date7, aoi2 -- lots of ruddy sediment, open water
+
+var dates = [date0, date0, date1, date1, date2, date2, date3, date4, date4, date5, date5, date6, date7, date7];
+
+var aois = [aoi1, aoi4, aoi1, aoi9, aoi12, aoi8, aoi10, aoi2, aoi6, aoi5, aoi15, aoi9, aoi4, aoi2];
+
+var aoi_ids = [1, 4, 1, 9, 12, 8, 10, 2, 6, 5, 15, 9, 4, 2];
+
+// load Landsat 4, 5, 7 Surface Reflectance
+var l7 = ee.ImageCollection('LANDSAT/LE07/C02/T1_L2');
+var l5 = ee.ImageCollection('LANDSAT/LT05/C02/T1_L2');
+var l4 = ee.ImageCollection('LANDSAT/LT04/C02/T1_L2');
+
+// the metadata for these layers are the same, so we don't need any placeholder layers for harmonization //
+var l457 = l4.merge(l5).merge(l7);
+
+//filter for desired PRs
+var ROWS = ee.List([27, 28]);
+var l457 = l457
+  .filter(ee.Filter.eq('WRS_PATH', 26))
+  .filter(ee.Filter.inList('WRS_ROW', ROWS));
+  
+l457.aside(print);
+
+// Applies scaling factors to LS4,5,7
+function applyScaleFactors(image) {
+  var opticalBands = image.select('SR_B.').multiply(0.0000275).add(-0.2);
+  var thermalBands = image.select('ST_B.*').multiply(0.00341802).add(149.0);
+  return image.addBands(opticalBands, null, true)
+              .addBands(thermalBands, null, true);
+}
+
+var l457 = l457
+  .map(applyScaleFactors);
+  
+//------------------------//
+// QA FILTERS ------------//
+//------------------------//
+
+// filter out saturated pixels
+function satMask(image){
+  var sat = image.select('QA_RADSAT');
+  var noSat = sat.eq(0);
+  return image.updateMask(noSat);
+}
+
+var l457 = l457.map(satMask);
+
+// Filter for water, clouds, etc ----- //
+function fMask(image) {
+  var qa = image.select('QA_PIXEL');
+  var water = qa.bitwiseAnd(1 << 7);
+  var cloudqa = qa.bitwiseAnd(1 << 1)
+    .where(qa.bitwiseAnd(1 << 2), ee.Image(2))
+    .where(qa.bitwiseAnd(1 << 3), ee.Image(3))
+    .where(qa.bitwiseAnd(1 << 4), ee.Image(4))
+    .where(qa.bitwiseAnd(1 << 5), ee.Image(5));
+  var qaMask = cloudqa.eq(0);
+  return image.updateMask(qaMask).updateMask(water);
+}
+
+var l457 = l457.map(fMask);
+
+// ------------------------------- //
+// -- filter to specific scenes -- //
+// ------------------------------- //
+
+// function to clip to AOI function
+function clip(image) {
+  var cl_im = image.clip(aoi);
+  return cl_im;
+}
+
+var today = ee.Date(date7);
+var tomorrow = today.advance(1, 'days');
+var l457_oneDay = l457
+  .filterDate(today, tomorrow);
+  
+var aoi = aoi2;
+var aoi_id = 1;
+
+var l457_oneDay = l457_oneDay
+  .filterBounds(aoi)
+  .map(clip);
+
+l457_oneDay.aside(print);
+
+var l457_oneDay = l457_oneDay
+  .mosaic()
+  .set({'date': today,
+        'aoi': aoi_id});
+  
+l457_oneDay.aside(print);
+
+
+// mosaic function
+function mosaicOneDay(date, aoi, aoi_id){
+  var today = ee.Date(date);
+  var tomorrow = today.advance(1, 'days');
+  var l457_oneDay = l457
+    .filterDate(today, tomorrow)
+    .filterBounds(aoi)
+    .map(clip);
+  var mosOneDay = l457_oneDay
+    .mosaic()
+    .set({'date': today,
+          'aoi': aoi_id});
+  return mosOneDay;
+}
+
+// this is NOT the most elegant way of doing this
+// but GEE doesn't do for-loops and the nested functions
+// make my head spin, sooooo reptition for the win.
+var mos0_1 = mosaicOneDay(dates[0], aois[0], aoi_ids[0]);
+var mos0_4 = mosaicOneDay(dates[1], aois[1], aoi_ids[1]);
+var mos1_1 = mosaicOneDay(dates[2], aois[2], aoi_ids[2]);
+var mos1_9 = mosaicOneDay(dates[3], aois[3], aoi_ids[3]);
+var mos2_12 = mosaicOneDay(dates[4], aois[4], aoi_ids[4]);
+var mos2_8 = mosaicOneDay(dates[5], aois[5], aoi_ids[5]);
+var mos3_10 = mosaicOneDay(dates[6], aois[6], aoi_ids[6]);
+var mos4_2 = mosaicOneDay(dates[7], aois[7], aoi_ids[7]);
+var mos4_6 = mosaicOneDay(dates[8], aois[8], aoi_ids[8]);
+var mos5_5 = mosaicOneDay(dates[9], aois[9], aoi_ids[9]);
+var mos5_15 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
+var mos6_9 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
+var mos7_4 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
+var mos7_2 = mosaicOneDay(dates[13], aois[13], aoi_ids[13]);
+
+
+var validationCollection = ee.ImageCollection([mos0_1,
+                          mos0_4, mos1_1, mos1_9, mos2_12, mos2_8,
+                          mos3_10, mos4_2, mos4_6, mos5_5, mos5_15,
+                          mos6_9, mos7_4, mos7_2]);
+
+validationCollection.aside(print);
+
+Export.table.toAsset(validationCollection);
+
+// ------------------------------- //
+// -- add vis params-------------- //
+// ------------------------------- //
+
+var l457_style_tc = {
+  bands: ['SR_B3', 'SR_B2', 'SR_B1'],
+  min: -0.01,
+  max: 0.20
+};
+
+
+// ------------------------------- //
+// -- show on map and center scene -- //
+// ------------------------------- //
+
+Map.addLayer(l457_oneDay, l457_style_tc, 'True Color');
+  Map.centerObject(aoi, 12);
+
+ 

--- a/eePlumB/Z_PrepAOI/validationSet_L457.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L457.js
@@ -3,6 +3,7 @@
 // written by B. Steele
 // last modified 2023-03-14
 
+var sup_noHarbor = ee.FeatureCollection('projects/ee-ross-superior/assets/aoi_superior_no_harbor');
 var aoi1 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_1');
 var aoi2 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_2');
 var aoi3 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_3');
@@ -129,6 +130,7 @@ var l457 = l457.map(fMask);
 // -- filter to specific scenes -- //
 // ------------------------------- //
 
+/*
 // function to clip to AOI function
 function clip(image) {
   var cl_im = image.clip(aoi);
@@ -154,7 +156,7 @@ var l457_oneDay = l457_oneDay
   .set({'date': today,
         'aoi': aoi_id});
   
-l457_oneDay.aside(print);
+l457_oneDay.aside(print);*/
 
 
 // mosaic function
@@ -163,14 +165,17 @@ function mosaicOneDay(date, aoi, aoi_id){
   var tomorrow = today.advance(1, 'days');
   var l457_oneDay = l457
     .filterDate(today, tomorrow)
-    .filterBounds(aoi)
-    .map(clip);
+    .filterBounds(aoi);
+  var mission = l457_oneDay.first().get('SPACECRAFT_ID');
   var mosOneDay = l457_oneDay
     .mosaic()
-    .set({'date': today,
-          'aoi': aoi_id});
+    .set({'date': date,
+          'aoi': aoi_id,
+          'mission': mission
+    });
   return mosOneDay;
 }
+
 
 // this is NOT the most elegant way of doing this
 // but GEE doesn't do for-loops and the nested functions
@@ -190,24 +195,13 @@ var mos6_9 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
 var mos7_4 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
 var mos7_2 = mosaicOneDay(dates[13], aois[13], aoi_ids[13]);
 
-mos0_1.aside(print)
-var validationCollection = ee.ImageCollection([
-                          mos0_1, mos0_4, 
-                          mos1_1, mos1_9, 
-                          mos2_12, mos2_8,
-                          mos3_10, 
-                          mos4_2, mos4_6, 
-                          mos5_5, mos5_15,
-                          mos6_9, 
-                          mos7_4, mos7_2]);
 
-validationCollection.aside(print);
 
 // for whatever reason, I can't loop through or functionalize the export, so
 // we're doing this the most convoluted and least data science-y way ever
 
 //get the image
-var processMos = function(mosaic){
+var processMos = function(mosaic, mos_aoi){
   //get the date and aoi
   var d = mosaic.get('date');
   var dstr = ee.Date(d).format('yyyy-MM-dd');
@@ -226,34 +220,37 @@ var processMos = function(mosaic){
     'description': id.getInfo(),
     'assetId': assetId.getInfo(),
     'pyramidingPolicy': 'mode',
+    'crs': 'EPSG:4326',
     'scale': 30,
+    'region': mos_aoi.geometry(),
     'maxPixels': 1e13
   });
-  
+
 };
 
+
 //select only bands for ux and export indiv
-processMos(mos0_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos0_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos0_1, aoi1);
+processMos(mos0_4, aoi4);
 
-processMos(mos1_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos1_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos1_1, aoi1);
+processMos(mos1_9, aoi9);
 
-processMos(mos2_12.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos2_8.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos2_12, aoi12);
+processMos(mos2_8, aoi8);
 
-processMos(mos3_10.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos3_10, aoi10);
 
-processMos(mos4_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos4_6.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos4_2, aoi2);
+processMos(mos4_6, aoi6);
 
-processMos(mos5_5.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos5_15.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos5_5, aoi5);
+processMos(mos5_15, aoi15);
 
-processMos(mos6_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos6_9, aoi9);
 
-processMos(mos7_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos7_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos7_4, aoi4);
+processMos(mos7_2, aoi2);
 
 /*
 // ------------------------------- //

--- a/eePlumB/Z_PrepAOI/validationSet_L457.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L457.js
@@ -3,7 +3,6 @@
 // written by B. Steele
 // last modified 2023-03-14
 
-var sup_noHarbor = ee.FeatureCollection('projects/ee-ross-superior/assets/aoi_superior_no_harbor');
 var aoi1 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_1');
 var aoi2 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_2');
 var aoi3 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_3');
@@ -111,7 +110,15 @@ function satMask(image){
 
 var l457 = l457.map(satMask);
 
-// Filter for water, clouds, etc ----- //
+//Filter for water //
+function findWater(image) {
+  var qa = image.select('QA_PIXEL');
+  var water = qa.bitwiseAnd(1 << 7);
+  return image.updateMask(water);
+}
+var l457 = l457.map(findWater);
+
+/*// Filter for water, clouds, etc ----- //
 function fMask(image) {
   var qa = image.select('QA_PIXEL');
   var water = qa.bitwiseAnd(1 << 7);
@@ -124,7 +131,7 @@ function fMask(image) {
   return image.updateMask(qaMask).updateMask(water);
 }
 
-var l457 = l457.map(fMask);
+var l457 = l457.map(fMask);*/
 
 // ------------------------------- //
 // -- filter to specific scenes -- //
@@ -173,7 +180,7 @@ function mosaicOneDay(date, aoi, aoi_id){
           'aoi': aoi_id,
           'mission': mission
     });
-  return mosOneDay;
+  return mosOneDay.clip(aoi);
 }
 
 
@@ -252,8 +259,8 @@ processMos(mos6_9, aoi9);
 processMos(mos7_4, aoi4);
 processMos(mos7_2, aoi2);
 
-/*
-// ------------------------------- //
+
+/*// ------------------------------- //
 // -- add vis params-------------- //
 // ------------------------------- //
 
@@ -269,5 +276,5 @@ var l457_style_tc = {
 // ------------------------------- //
 
 Map.addLayer(l457_oneDay, l457_style_tc, 'True Color');
-  Map.centerObject(aoi, 12);
+Map.centerObject(aoi, 12);
 */

--- a/eePlumB/Z_PrepAOI/validationSet_L457.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L457.js
@@ -1,7 +1,7 @@
 // This script creates the validation collection for eePlumB 
 // for Landsat 4, 5, 7 at Lake Superior
 // written by B. Steele
-// last modified 2020-03-14
+// last modified 2023-03-14
 
 var aoi1 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_1');
 var aoi2 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_2');
@@ -50,9 +50,23 @@ var date7 = '2020-05-31';
 //date7, aoi4 -- deep sediment, open water, near-shore artifacts (near canal park)
 //date7, aoi2 -- lots of ruddy sediment, open water
 
-var dates = [date0, date0, date1, date1, date2, date2, date3, date4, date4, date5, date5, date6, date7, date7];
+var dates = [date0, date0, 
+            date1, date1, 
+            date2, date2, 
+            date3, 
+            date4, date4, 
+            date5, date5, 
+            date6, 
+            date7, date7];
 
-var aois = [aoi1, aoi4, aoi1, aoi9, aoi12, aoi8, aoi10, aoi2, aoi6, aoi5, aoi15, aoi9, aoi4, aoi2];
+var aois = [aoi1, aoi4, 
+            aoi1, aoi9,
+            aoi12, aoi8, 
+            aoi10, 
+            aoi2, aoi6, 
+            aoi5, aoi15, 
+            aoi9, 
+            aoi4, aoi2];
 
 var aoi_ids = [1, 4, 1, 9, 12, 8, 10, 2, 6, 5, 15, 9, 4, 2];
 
@@ -176,16 +190,72 @@ var mos6_9 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
 var mos7_4 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
 var mos7_2 = mosaicOneDay(dates[13], aois[13], aoi_ids[13]);
 
-
-var validationCollection = ee.ImageCollection([mos0_1,
-                          mos0_4, mos1_1, mos1_9, mos2_12, mos2_8,
-                          mos3_10, mos4_2, mos4_6, mos5_5, mos5_15,
-                          mos6_9, mos7_4, mos7_2]);
+mos0_1.aside(print)
+var validationCollection = ee.ImageCollection([
+                          mos0_1, mos0_4, 
+                          mos1_1, mos1_9, 
+                          mos2_12, mos2_8,
+                          mos3_10, 
+                          mos4_2, mos4_6, 
+                          mos5_5, mos5_15,
+                          mos6_9, 
+                          mos7_4, mos7_2]);
 
 validationCollection.aside(print);
 
-Export.table.toAsset(validationCollection);
+// for whatever reason, I can't loop through or functionalize the export, so
+// we're doing this the most convoluted and least data science-y way ever
 
+//get the image
+var processMos = function(mosaic){
+  //get the date and aoi
+  var d = mosaic.get('date');
+  var dstr = ee.Date(d).format('yyyy-MM-dd');
+  var a = mosaic.get('aoi');
+  var astr = ee.String(a);
+  var id = ee.String('aoi_').cat(astr).cat('_').cat(dstr);
+
+  //apend with assetIDPrefix
+  var assetIDPrefix = 'projects/ee-ross-superior/assets/eePlumB_valSets/LS4-7_eePlumB_val';
+  var assetId = ee.String(assetIDPrefix).cat('_').cat(id);
+  var descrip = ee.String('Export').cat('_').cat(id);  
+  
+  //define task
+  var task = Export.image.toAsset({
+    'image': mosaic,
+    'description': id.getInfo(),
+    'assetId': assetId.getInfo(),
+    'pyramidingPolicy': 'mode',
+    'scale': 30,
+    'maxPixels': 1e13
+  });
+  
+};
+
+//select only bands for ux and export indiv
+processMos(mos0_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos0_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos1_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos1_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos2_12.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos2_8.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos3_10.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos4_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos4_6.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos5_5.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos5_15.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos6_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos7_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos7_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+/*
 // ------------------------------- //
 // -- add vis params-------------- //
 // ------------------------------- //
@@ -203,5 +273,4 @@ var l457_style_tc = {
 
 Map.addLayer(l457_oneDay, l457_style_tc, 'True Color');
   Map.centerObject(aoi, 12);
-
- 
+*/

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -206,7 +206,7 @@ var processMos = function(mosaic){
   var id = ee.String('aoi_').cat(astr).cat('_').cat(dstr);
 
   //apend with assetIDPrefix
-  var assetIDPrefix = 'projects/ee-ross-superior/assets/eePlumB_valSets/LS4-7_eePlumB_val';
+  var assetIDPrefix = 'projects/ee-ross-superior/assets/eePlumB_valSets/LS89_eePlumB_val';
   var assetId = ee.String(assetIDPrefix).cat('_').cat(id);
   var descrip = ee.String('Export').cat('_').cat(id);  
   

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -1,7 +1,7 @@
 // This script creates the validation collection for eePlumB 
 // for Landsat 8 & 9 at Lake Superior
 // written by B. Steele
-// last modified 2020-03-14
+// last modified 2020-03-15
 
 var aoi1 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_1');
 var aoi2 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_2');
@@ -91,7 +91,15 @@ function satMask(image){
 
 var l89 = l89.map(satMask);
 
-// Filter for water, clouds, etc ----- //
+//Filter for water //
+function findWater(image) {
+  var qa = image.select('QA_PIXEL');
+  var water = qa.bitwiseAnd(1 << 7);
+  return image.updateMask(water);
+}
+var l89 = l89.map(findWater);
+
+/*// Filter for water, clouds, etc ----- //
 function fMask(image) {
   var qa = image.select('QA_PIXEL');
   var water = qa.bitwiseAnd(1 << 7);
@@ -104,7 +112,7 @@ function fMask(image) {
   return image.updateMask(qaMask).updateMask(water);
 }
 
-var l89 = l89.map(fMask);
+var l89 = l89.map(fMask);*/
 
 // ------------------------------- //
 // -- filter to specific scenes -- //
@@ -166,7 +174,7 @@ function mosaicOneDay(date, aoi, aoi_id){
           'aoi': aoi_id,
           'mission': mission
     });
-  return mosOneDay;
+  return mosOneDay.clip(aoi);
 }
 
 // this is NOT the most elegant way of doing this

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -172,20 +172,19 @@ function mosaicOneDay(date, aoi, aoi_id){
 // make my head spin, sooooo reptition for the win.
 var mos0_9 = mosaicOneDay(dates[0], aois[0], aoi_ids[0]);
 var mos0_1 = mosaicOneDay(dates[1], aois[1], aoi_ids[1]);
-var mos1_1 = mosaicOneDay(dates[2], aois[2], aoi_ids[2]);
-var mos1_4 = mosaicOneDay(dates[3], aois[3], aoi_ids[3]);
-var mos1_11 = mosaicOneDay(dates[4], aois[4], aoi_ids[4]);
-var mos2_2 = mosaicOneDay(dates[5], aois[5], aoi_ids[5]);
-var mos2_10 = mosaicOneDay(dates[6], aois[6], aoi_ids[6]);
+var mos0_16 = mosaicOneDay(dates[2], aois[2], aoi_ids[2]);
+var mos1_1 = mosaicOneDay(dates[3], aois[3], aoi_ids[3]);
+var mos1_4 = mosaicOneDay(dates[4], aois[4], aoi_ids[4]);
+var mos1_11 = mosaicOneDay(dates[5], aois[5], aoi_ids[5]);
+var mos2_2 = mosaicOneDay(dates[6], aois[6], aoi_ids[6]);
+var mos2_10 = mosaicOneDay(dates[7], aois[7], aoi_ids[7]);
+var mos3_16 = mosaicOneDay(dates[8], aois[8], aoi_ids[8]);
+var mos3_5 = mosaicOneDay(dates[9], aois[9], aoi_ids[9]);
+var mos3_11 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
+var mos4_1 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
+var mos4_13 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
 
-var mos3_16 = mosaicOneDay(dates[7], aois[7], aoi_ids[7]);
-var mos3_5 = mosaicOneDay(dates[8], aois[8], aoi_ids[8]);
-var mos3_11 = mosaicOneDay(dates[9], aois[9], aoi_ids[9]);
-
-var mos4_1 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
-var mos4_13 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
-
-var validationCollection = ee.ImageCollection([mos0_9, mos0_1, 
+var validationCollection = ee.ImageCollection([mos0_9, mos0_1, mos0_16,
                           mos1_1, mos1_4, mos1_11,
                           mos2_2, mos2_10, 
                           mos3_16, mos3_5, mos3_11, 
@@ -223,22 +222,23 @@ var processMos = function(mosaic){
 };
 
 //select only bands for ux and export indiv
-processMos(mos0_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos0_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos0_9.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos0_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos0_16.select(['SR_B4', 'SR_B3', 'SR_B2']));
 
-processMos(mos1_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos1_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos1_11.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos1_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos1_4.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos1_11.select(['SR_B4', 'SR_B3', 'SR_B2']));
 
-processMos(mos2_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos2_10.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos2_2.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos2_10.select(['SR_B4', 'SR_B3', 'SR_B2']));
 
-processMos(mos3_16.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos3_5.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos3_11.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos3_16.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos3_5.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos3_11.select(['SR_B4', 'SR_B3', 'SR_B2']));
 
-processMos(mos4_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
-processMos(mos4_13.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos4_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos4_13.select(['SR_B4', 'SR_B3', 'SR_B2']));
 
 /*
 // ------------------------------- //

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -110,7 +110,7 @@ var l89 = l89.map(fMask);
 // -- filter to specific scenes -- //
 // ------------------------------- //
 
-// function to clip to AOI function
+/*// function to clip to AOI function
 function clip(image) {
   var cl_im = image.clip(aoi);
   return cl_im;
@@ -150,7 +150,7 @@ var l89_oneDay = l89_oneDay
         'aoi': aoi_id});
   
 l89_oneDay.aside(print);
-
+*/
 
 // mosaic function
 function mosaicOneDay(date, aoi, aoi_id){
@@ -158,12 +158,14 @@ function mosaicOneDay(date, aoi, aoi_id){
   var tomorrow = today.advance(1, 'days');
   var l89_oneDay = l89
     .filterDate(today, tomorrow)
-    .filterBounds(aoi)
-    .map(clip);
+    .filterBounds(aoi);
+  var mission = l89_oneDay.first().get('SPACECRAFT_ID');
   var mosOneDay = l89_oneDay
     .mosaic()
-    .set({'date': today,
-          'aoi': aoi_id});
+    .set({'date': date,
+          'aoi': aoi_id,
+          'mission': mission
+    });
   return mosOneDay;
 }
 
@@ -184,19 +186,12 @@ var mos3_11 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
 var mos4_1 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
 var mos4_13 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
 
-var validationCollection = ee.ImageCollection([mos0_9, mos0_1, mos0_16,
-                          mos1_1, mos1_4, mos1_11,
-                          mos2_2, mos2_10, 
-                          mos3_16, mos3_5, mos3_11, 
-                          mos4_1, mos4_13]);
-
-validationCollection.aside(print);
 
 // for whatever reason, I can't loop through or functionalize the export, so
 // we're doing this the most convoluted and least data science-y way ever
 
 //get the image
-var processMos = function(mosaic){
+var processMos = function(mosaic, mos_aoi){
   //get the date and aoi
   var d = mosaic.get('date');
   var dstr = ee.Date(d).format('yyyy-MM-dd');
@@ -215,30 +210,32 @@ var processMos = function(mosaic){
     'description': id.getInfo(),
     'assetId': assetId.getInfo(),
     'pyramidingPolicy': 'mode',
+    'crs': 'EPSG:4326',
     'scale': 30,
+    'region': mos_aoi.geometry(),
     'maxPixels': 1e13
   });
   
 };
 
 //select only bands for ux and export indiv
-processMos(mos0_9.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos0_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos0_16.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos0_9, aoi9);
+processMos(mos0_1, aoi1);
+processMos(mos0_16, aoi16);
 
-processMos(mos1_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos1_4.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos1_11.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos1_1, aoi1);
+processMos(mos1_4, aoi4);
+processMos(mos1_11, aoi11);
 
-processMos(mos2_2.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos2_10.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos2_2, aoi2);
+processMos(mos2_10, aoi10);
 
-processMos(mos3_16.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos3_5.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos3_11.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos3_16, aoi16);
+processMos(mos3_5, aoi5);
+processMos(mos3_11, aoi11);
 
-processMos(mos4_1.select(['SR_B4', 'SR_B3', 'SR_B2']));
-processMos(mos4_13.select(['SR_B4', 'SR_B3', 'SR_B2']));
+processMos(mos4_1, aoi1);
+processMos(mos4_13, aoi13);
 
 /*
 // ------------------------------- //

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -1,4 +1,5 @@
-// This script creates the validation collection for eePlumB for Landsat 8 & 9
+// This script creates the validation collection for eePlumB 
+// for Landsat 8 & 9 at Lake Superior
 // written by B. Steele
 // last modified 2020-03-14
 
@@ -13,6 +14,12 @@ var aoi8 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/Super
 var aoi9 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_9');
 var aoi10 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_10');
 var aoi11 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_11');
+var aoi12 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_12');
+var aoi13 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_13');
+var aoi14 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_14');
+var aoi15 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_15');
+var aoi16 = ee.FeatureCollection('projects/ee-ross-superior/assets/tiledAOI/SuperiorAOI_16');
+
 
 //------------------------------------//
 // DATES FOR USER VALIDATION ------------//
@@ -24,36 +31,26 @@ var date3 = '2022-10-28';
 var date4 = '2022-04-19';
 
 // notes from b's noodling around - to see these yourself, uncomment
-// the last two blocks of code and fill in dates on line 123, aoi on 128,
-// and aoi id on 129
-//date0, aoi9 -- cloud artifacts
-//date0, aoi1 -- clear sediment on south shore; cloud artifacts in NE corner
-//date1, aoi1 -- lots of sediment and deep sediment that looks like blooms
-//date1, aoi2 -- lots of sediment and deep sediment that looks like blooms
-//date1, aoi4 -- unmasked clouds, sediment along s shore
-//date1, aoi9 -- open water (arguable deep sed at bottom)
-//date2, aoi1 -- sediment swirls, near harbor very brown
-//date2, aoi7 -- stringy sediment between island and land, sediment near inlet, lots of mixed shore pixels
-//date2, aoi11 -- open water
-//date3, aoi10 -- cloud artifacts (especially in bottom r; sediment between islands
-//date3, aoi2 -- lots of wind-blown suspended sediment
-//date3, aoi8 -- cloud artifacts
-//date4, aoi3 -- cloud artifacts, sediment s of island
-//date4, aoi1 -- dark dark sediment
-//date4, aoi5 -- open water except near inlet of knife river
-//date4, aoi6 -- cloud artifacts at the bottom edge, deep sediment
+// the last two blocks of code and fill in dates on line 119, aoi on 124,
+// and optionally aoi id on 125
 
-var dates = [date0,date0, 
-                    date1,date1,date1,date1, 
-                    date2,,date2,date2, 
-                    date3,date3,date3,
-                    date4,date4,date4,date4];
+var dates = [date0,date0, date0,
+            date1,date1,date1, 
+            date2,date2, 
+            date3,date3,date3,
+            date4,date4];
 
-var aois = [aoi9, aoi1, aoi1, aoi2, aoi4, aoi9, aoi1, 
-                  aoi7, aoi11, aoi10, aoi2, aoi8, aoi3, aoi1, aoi5, 
-                  aoi6];
+var aois = [aoi9, aoi1, aoi16, 
+            aoi1, aoi4, aoi11, 
+            aoi2, aoi10, 
+            aoi16, aoi5, aoi11, 
+            aoi1, aoi13];
 
-var aoi_ids = [9, 1, 1, 2, 4, 9, 1, 7, 11, 10, 2, 8, 3, 1, 5, 6];
+var aoi_ids = [9, 1, 16,
+              1, 4, 11, 
+              2, 10, 
+              16, 5, 11, 
+              1, 13];
 
 // load Landsat 8 and 9 Surface Reflectance
 var l9 = ee.ImageCollection("LANDSAT/LC09/C02/T1_L2");
@@ -68,7 +65,7 @@ var l89 = l89
   .filter(ee.Filter.eq('WRS_PATH', 26))
   .filter(ee.Filter.inList('WRS_ROW', ROWS));
   
-l89.aside(print)
+l89.aside(print);
 
 // Applies scaling factors to LS8/9
 function applyScaleFactors(image) {
@@ -119,13 +116,27 @@ function clip(image) {
   return cl_im;
 }
 
-var today = ee.Date(date2);
+var today = ee.Date(date4);
 var tomorrow = today.advance(1, 'days');
 var l89_oneDay = l89
   .filterDate(today, tomorrow);
   
-var aoi = aoi6;
+var aoi = aoi16;
 var aoi_id = 1;
+
+//date0, aoi9 -- open water, cloud artifacts
+//date0, aoi1 -- clear sediment on south shore
+//date0, aoi16 - open water
+//date1, aoi1 -- lots of sediment and deep sediment that looks like blooms
+//date1, aoi4 -- sediment near harbor, unmasked clouds, shoreline artifacts (jetties)
+//date1, aoi11 -- sediment along shores, looks like blooms (but is more likely plumes)
+//date2, aoi2 -- ruddy sediment, open water (top right)
+//date2, aoi10 -- stringy sediment between island and land, sediment near inlet, open water
+//date3, aoi16 -- open water 
+//date3, aoi5 -- lots of wind-blown suspended sediment
+//date3, aoi11 -- cloud artifacts, sediment between islands
+//date4, aoi1 -- dark dark sediment, cloud artifacts along s shore
+//date4, aoi13 -- open water except near inlets
 
 var l89_oneDay = l89_oneDay
   .filterBounds(aoi)
@@ -162,32 +173,29 @@ function mosaicOneDay(date, aoi, aoi_id){
 var mos0_9 = mosaicOneDay(dates[0], aois[0], aoi_ids[0]);
 var mos0_1 = mosaicOneDay(dates[1], aois[1], aoi_ids[1]);
 var mos1_1 = mosaicOneDay(dates[2], aois[2], aoi_ids[2]);
-var mos1_2 = mosaicOneDay(dates[3], aois[3], aoi_ids[3]);
-var mos1_4 = mosaicOneDay(dates[4], aois[4], aoi_ids[4]);
-var mos1_9 = mosaicOneDay(dates[5], aois[5], aoi_ids[5]);
-var mos2_1 = mosaicOneDay(dates[6], aois[6], aoi_ids[6]);
-var mos2_7 = mosaicOneDay(dates[7], aois[7], aoi_ids[7]);
-var mos2_11 = mosaicOneDay(dates[8], aois[8], aoi_ids[8]);
-var mos3_10 = mosaicOneDay(dates[9], aois[9], aoi_ids[9]);
-var mos3_2 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
-var mos3_8 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
-var mos4_3 = mosaicOneDay(dates[12], aois[12], aoi_ids[12]);
-var mos4_1 = mosaicOneDay(dates[13], aois[13], aoi_ids[13]);
-var mos4_5 = mosaicOneDay(dates[14], aois[14], aoi_ids[14]);
-var mos4_6 = mosaicOneDay(dates[15], aois[15], aoi_ids[15]);
+var mos1_4 = mosaicOneDay(dates[3], aois[3], aoi_ids[3]);
+var mos1_11 = mosaicOneDay(dates[4], aois[4], aoi_ids[4]);
+var mos2_2 = mosaicOneDay(dates[5], aois[5], aoi_ids[5]);
+var mos2_10 = mosaicOneDay(dates[6], aois[6], aoi_ids[6]);
 
+var mos3_16 = mosaicOneDay(dates[7], aois[7], aoi_ids[7]);
+var mos3_5 = mosaicOneDay(dates[8], aois[8], aoi_ids[8]);
+var mos3_11 = mosaicOneDay(dates[9], aois[9], aoi_ids[9]);
 
-var validationCollection = ee.ImageCollection([mos0_9,
-                          mos0_1, mos1_1, mos1_2, mos1_4, mos1_9,
-                          mos2_1, mos2_7, mos2_11, mos3_10, mos3_2,
-                          mos3_8, mos4_3, mos4_1, mos4_5, mos4_6
-                          ]);
+var mos4_1 = mosaicOneDay(dates[10], aois[10], aoi_ids[10]);
+var mos4_13 = mosaicOneDay(dates[11], aois[11], aoi_ids[11]);
+
+var validationCollection = ee.ImageCollection([mos0_9, mos0_1, 
+                          mos1_1, mos1_4, mos1_11,
+                          mos2_2, mos2_10, 
+                          mos3_16, mos3_5, mos3_11, 
+                          mos4_1, mos4_13]);
 
 validationCollection.aside(print);
 
 Export.table.toAsset(validationCollection);
 
-/*// ------------------------------- //
+// ------------------------------- //
 // -- add vis params-------------- //
 // ------------------------------- //
 
@@ -203,6 +211,4 @@ var l89_style_tc = {
 // ------------------------------- //
 
 Map.addLayer(l89_oneDay, l89_style_tc, 'True Color');
-Map.centerObject(aoi);
-*/
- 
+Map.centerObject(aoi, 12);

--- a/eePlumB/Z_PrepAOI/validationSet_L89.js
+++ b/eePlumB/Z_PrepAOI/validationSet_L89.js
@@ -193,8 +193,54 @@ var validationCollection = ee.ImageCollection([mos0_9, mos0_1,
 
 validationCollection.aside(print);
 
-Export.table.toAsset(validationCollection);
+// for whatever reason, I can't loop through or functionalize the export, so
+// we're doing this the most convoluted and least data science-y way ever
 
+//get the image
+var processMos = function(mosaic){
+  //get the date and aoi
+  var d = mosaic.get('date');
+  var dstr = ee.Date(d).format('yyyy-MM-dd');
+  var a = mosaic.get('aoi');
+  var astr = ee.String(a);
+  var id = ee.String('aoi_').cat(astr).cat('_').cat(dstr);
+
+  //apend with assetIDPrefix
+  var assetIDPrefix = 'projects/ee-ross-superior/assets/eePlumB_valSets/LS4-7_eePlumB_val';
+  var assetId = ee.String(assetIDPrefix).cat('_').cat(id);
+  var descrip = ee.String('Export').cat('_').cat(id);  
+  
+  //define task
+  var task = Export.image.toAsset({
+    'image': mosaic,
+    'description': id.getInfo(),
+    'assetId': assetId.getInfo(),
+    'pyramidingPolicy': 'mode',
+    'scale': 30,
+    'maxPixels': 1e13
+  });
+  
+};
+
+//select only bands for ux and export indiv
+processMos(mos0_9.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos0_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos1_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos1_4.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos1_11.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos2_2.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos2_10.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos3_16.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos3_5.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos3_11.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+processMos(mos4_1.select(['SR_B1', 'SR_B2', 'SR_B3']));
+processMos(mos4_13.select(['SR_B1', 'SR_B2', 'SR_B3']));
+
+/*
 // ------------------------------- //
 // -- add vis params-------------- //
 // ------------------------------- //
@@ -212,3 +258,4 @@ var l89_style_tc = {
 
 Map.addLayer(l89_oneDay, l89_style_tc, 'True Color');
 Map.centerObject(aoi, 12);
+*/


### PR DESCRIPTION
Woof! Apparently exporting image collections to assets is just downright terrible. 

__Create a validation image collection__
1) creation of the 4-7 validation workflow. `eePlumB/Z_PrepAOI/validationSet_L457.js`
2) edits to the validation dataset for 4-7 and 8-9 to reflect new AOI tiles. 
3) absolute hack job of creating the image collection for validation. I'm not even sure if this is going to work yet, I've had images processing for about an hour now, so cross your fingers. If this doesn't work, I'll bake it into the validation script. GROD folks had it easy by just referencing an extent and grabbing the first cloud-free image, we have to reference the extent and the date.... I want it to be user-friendly and baking-it-in is not the best for UX.

Asks of you:
1) can you make sure you have access to all the aoi tiles? I think I made all of them public, but I'd appreciate your help making sure that's the case. 
2) could you view the sets in 4-7 and 8-9 from the outside and help me narrow down to 10 tiles/dates for the validation test? In an ideal world, these span from super easy, to kind of tricky, but don't necessarily need to cover all tiles. It would be great if there was at least one tile/date for each Landsat mission included.

Later commits Closes #16 