### PR TITLE
Prelim k-means script and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 #python venvs
 */env/
+env/
 
 #knit output
 reports/images/*

--- a/eePlumB/Z_PrepAOI/TileAOI.Rmd
+++ b/eePlumB/Z_PrepAOI/TileAOI.Rmd
@@ -22,11 +22,7 @@ shp_dir = '/Users/steeleb/Documents/GitHub/Superior-Plume-Bloom/data/aoi/'
 ## Read in AOI shapefile
 
 ```{r}
-shape = read_sf(file.path(shp_dir, 'superior_no_harbor', 'superior_no_harbor.shp'))
-
-#in our case, we need to filter for water
-shape = shape %>% 
-  filter(Feature == 'Water')
+shape = read_sf(file.path(shp_dir, 'NHDPlusHR', 'NHDPlusHR_superior_crop_noHarbor.shp'))
 
 #plot quickly to confirm
 plot(shape['Feature'])
@@ -38,7 +34,7 @@ You might need to play around with the cellsize to adjust the grid your your nee
 
 ```{r}
 tiles = st_make_grid(shape,
-                     cellsize = c(30000, 20000))#units are square meters for Superior
+                     cellsize = c(35000, 25000))#units are square meters for Superior
 tiles = tiles[shape]
 
 #plot quickly to confirm

--- a/preliminary_kmeans/GEE_prelim_kmeans.js
+++ b/preliminary_kmeans/GEE_prelim_kmeans.js
@@ -1,0 +1,303 @@
+// adapted from https://www.eefabook.org/ Section F3.3  //
+// for use in creation of preliminary rasters for Lindsay's pipeline //
+
+var l9 = ee.ImageCollection("LANDSAT/LC09/C02/T1_L2"),
+    l8 = ee.ImageCollection("LANDSAT/LC08/C02/T1_L2"),
+    l7 = ee.ImageCollection("LANDSAT/LE07/C02/T1_L2"),
+    l5 = ee.ImageCollection('LANDSAT/LT05/C02/T1_L2'),
+    l4 = ee.ImageCollection('LANDSAT/LT04/C02/T1_L2'),
+    aoi = ee.FeatureCollection("projects/ee-ross-superior/assets/aoi_superior_no_harbor")
+      .filter(ee.Filter.eq('Feature', 'Water'));
+    
+// rename L7 bands to match l8/9
+var bn7 = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7', 'ST_B6', 'QA_PIXEL', 'QA_RADSAT'];
+// new band names
+var bns = ['SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7', 'ST_B10', 'QA_PIXEL', 'QA_RADSAT'];
+var l4 = l4.select(bn7, bns);
+var l5 = l5.select(bn7, bns);
+var l7 = l7.select(bn7, bns);
+var l8 = l8.select(bns);
+var l9 = l9.select(bns);
+
+// merge collections
+var ls = ee.ImageCollection(l9).merge(l8).merge(l7).merge(l5).merge(l4);
+
+//filter for desired PRs
+var ROWS = ee.List([27, 28]);
+var ls = ls
+  .filter(ee.Filter.eq('WRS_PATH', 26))
+  .filter(ee.Filter.inList('WRS_ROW', ROWS))
+  .filter(ee.Filter.lt('CLOUD_COVER', 10));
+  
+// Applies scaling factors
+function applyScaleFactors(image) {
+  var opticalBands = image.select('SR_B.').multiply(0.0000275).add(-0.2);
+  var thermalBands = image.select('ST_B.*').multiply(0.00341802).add(149.0);
+  return image.addBands(opticalBands, null, true)
+              .addBands(thermalBands, null, true);
+}
+
+var ls = ls
+  .map(applyScaleFactors);
+  
+ls.aside(print);
+// CLIP FUNCTION
+function clip(image) {
+  var cl_im = image.clip(aoi);
+  return cl_im;
+}
+
+// mosaic function
+function mosaicOneDay(date, mission){
+  var today = ee.Date(date);
+  var tomorrow = today.advance(1, 'days');
+  var oneDay = ls
+    .filterDate(today, tomorrow)
+    .filterBounds(aoi)
+    .filter(ee.Filter.eq('SPACECRAFT_ID', mission));
+  var mosOneDay = oneDay
+    .mosaic()
+    .set({'date': date,
+          'mission': mission
+    });
+  return mosOneDay.clip(aoi);
+}
+
+var img1 = mosaicOneDay('2022-05-05', 'LANDSAT_9');
+var img2 = mosaicOneDay('2022-06-22', 'LANDSAT_9');
+var img3 = mosaicOneDay('2022-07-08', 'LANDSAT_9');
+var img4 = mosaicOneDay('2022-08-09', 'LANDSAT_9');
+var img5 = mosaicOneDay('2022-10-28', 'LANDSAT_9');
+var img7 = mosaicOneDay('2019-04-19', 'LANDSAT_8');
+var img8 = mosaicOneDay('2019-05-05', 'LANDSAT_8');
+var img9 = mosaicOneDay('2019-05-21', 'LANDSAT_8');
+var img10 = mosaicOneDay('2019-06-22', 'LANDSAT_8');
+var img11 = mosaicOneDay('2019-07-24', 'LANDSAT_8');
+var img12 = mosaicOneDay('2019-09-26', 'LANDSAT_8');
+var img13 = mosaicOneDay('2007-05-12', 'LANDSAT_7');
+var img14 = mosaicOneDay('2007-06-13', 'LANDSAT_7');
+var img15 = mosaicOneDay('2007-06-29', 'LANDSAT_7');
+var img16 = mosaicOneDay('2007-07-31', 'LANDSAT_7');
+var img17 = mosaicOneDay('2007-08-16', 'LANDSAT_7');
+var img18 = mosaicOneDay('1998-05-27', 'LANDSAT_5');
+var img19 = mosaicOneDay('1998-08-31', 'LANDSAT_5');
+var img20 = mosaicOneDay('1998-09-16', 'LANDSAT_5');
+var img21 = mosaicOneDay('1998-10-02', 'LANDSAT_5');
+
+
+
+////////////////////////////////////////////////////////////
+// 1. Functions for kmeans
+////////////////////////////////////////////////////////////
+
+// This function does unsupervised clustering classification 
+// input = any image. All bands will be used for clustering.
+// numberOfUnsupervisedClusters = tunable parameter for how 
+//        many clusters to create.
+
+var afn_Kmeans = function(input, numberOfUnsupervisedClusters,
+    defaultStudyArea, nativeScaleOfImage) {
+
+    // Make a new sample set on the input. Here the sample set is 
+    // randomly selected spatially. 
+    var training = input.sample({
+        region: defaultStudyArea,
+        scale: nativeScaleOfImage,
+        numPixels: 1000
+    });
+
+    var cluster = ee.Clusterer.wekaKMeans(
+            numberOfUnsupervisedClusters)
+        .train(training);
+
+    // Now apply that clusterer to the raw image that was also passed in. 
+    var toexport = input.cluster(cluster);
+
+    // The first item is the unsupervised classification. Name the band.
+    var clusterUnsup = toexport.select(0).rename(
+        'unsupervisedClass');
+    return (clusterUnsup);
+};
+
+// 1.1 Simple normalization by maxes function.
+var afn_normalize_by_maxes = function(img, bandMaxes) {
+    return img.divide(bandMaxes);
+};
+
+// 1.2 Simple add mean to Band Name function
+var afn_addMeanToBandName = (function(i) {
+    return i + '_mean';
+});
+
+// 1.3 Seed Creation and SNIC segmentation Function
+var afn_SNIC = function(imageOriginal, SuperPixelSize, Compactness,
+    Connectivity, NeighborhoodSize, SeedShape) {
+    var theSeeds = ee.Algorithms.Image.Segmentation.seedGrid(
+        SuperPixelSize, SeedShape);
+    var snic2 = ee.Algorithms.Image.Segmentation.SNIC({
+        image: imageOriginal,
+        size: SuperPixelSize,
+        compactness: Compactness,
+        connectivity: Connectivity,
+        neighborhoodSize: NeighborhoodSize,
+        seeds: theSeeds
+    });
+    var theStack = snic2.addBands(theSeeds);
+    return (theStack);
+};
+
+////////////////////////////////////////////////////////////
+// 2. Parameters to function calls
+////////////////////////////////////////////////////////////
+ 
+// 2.1. Unsupervised KMeans Classification Parameters
+var numberOfUnsupervisedClusters = 4;
+
+// 2.2. Visualization and Saving parameters
+// For different images, you might want to change the min and max 
+// values to stretch. Useful for images 2 and 3, the normalized images.
+var centerObjectYN = true;
+
+// 2.3 Object-growing parameters to change
+// Adjustable Superpixel Seed and SNIC segmentation Parameters:
+// The superpixel seed location spacing, in pixels.
+var SNIC_SuperPixelSize = 16;
+// Larger values cause clusters to be more compact (square/hexagonal). 
+// Setting this to 0 disables spatial distance weighting.
+var SNIC_Compactness = 0;
+// Connectivity. Either 4 or 8. 
+var SNIC_Connectivity = 4;
+// Either 'square' or 'hex'.
+var SNIC_SeedShape = 'square';
+
+// 2.4 Parameters that can stay unchanged
+// Tile neighborhood size (to avoid tile boundary artifacts). Defaults to 2 * size.
+var SNIC_NeighborhoodSize = 2 * SNIC_SuperPixelSize;
+
+//////////////////////////////////////////////////////////
+// 3. Statements
+//////////////////////////////////////////////////////////
+
+// 3.1  Selecting Image to Classify 
+var whichImage = 1; // will be used to select among images
+if (whichImage == 1) {
+    var originalImage = img21;//no 6
+    var date = originalImage.get('date');
+    var mission = originalImage.get('mission');
+    var nativeScaleOfImage = 30;
+    var threeBandsToDraw = ['SR_B4', 'SR_B3', 'SR_B2'];
+    var bandsToUse = ['SR_B4', 'SR_B3', 'SR_B2'];
+    var bandMaxes = [1, 1, 1];
+    var drawMin = 0;
+    var drawMax = 0.3;
+    var defaultStudyArea = aoi;
+    var zoomArea = aoi;
+    }
+
+Map.addLayer(originalImage.select(threeBandsToDraw), {
+  min: 0,
+  max: 0.3
+}, '3.1 ' + mission.getInfo() + ' ' + date.getInfo(), true, 1);
+
+////////////////////////////////////////////////////////////
+// 4. Image Preprocessing 
+////////////////////////////////////////////////////////////
+var clippedImageSelectedBands = originalImage.clip(defaultStudyArea)
+    .select(bandsToUse);
+var ImageToUse = afn_normalize_by_maxes(clippedImageSelectedBands,
+    bandMaxes);
+
+/*Map.addLayer(ImageToUse.select(threeBandsToDraw), {
+        min: 0,
+        max: 0.3
+  },
+  '4.3 Pre-normalized image', true, 0);
+*/
+////////////////////////////////////////////////////////////
+// 5. SNIC Clustering
+////////////////////////////////////////////////////////////
+
+// This function returns a multi-banded image that has had SNIC
+// applied to it. It automatically determine the new names 
+// of the bands that will be returned from the segmentation.
+//print('5.1 Execute SNIC');
+var SNIC_MultiBandedResults = afn_SNIC(
+    ImageToUse,
+    SNIC_SuperPixelSize,
+    SNIC_Compactness,
+    SNIC_Connectivity,
+    SNIC_NeighborhoodSize,
+    SNIC_SeedShape
+);
+
+var SNIC_MultiBandedResults = SNIC_MultiBandedResults
+    .reproject('EPSG:3857', null, nativeScaleOfImage);
+//print('5.2 SNIC Multi-Banded Results', SNIC_MultiBandedResults);
+
+/*Map.addLayer(SNIC_MultiBandedResults.select('clusters')
+    .randomVisualizer(), {}, '5.3 SNIC Segment Clusters', true, 1);
+*/
+var theSeeds = SNIC_MultiBandedResults.select('seeds');
+/*Map.addLayer(theSeeds, {
+    palette: 'red'
+}, '5.4 Seed points of clusters', true, 1);
+*/
+var bandMeansToDraw = threeBandsToDraw.map(afn_addMeanToBandName);
+//print('5.5 band means to draw', bandMeansToDraw);
+var clusterMeans = SNIC_MultiBandedResults.select(bandMeansToDraw);
+/*print('5.6 Cluster Means by Band', clusterMeans);
+Map.addLayer(clusterMeans, {
+    min: drawMin,
+    max: drawMax
+}, '5.7 Image repainted by segments', true, 0);
+*/
+////////////////////////////////////////////////////////////
+// 6. Execute Classifications
+////////////////////////////////////////////////////////////
+
+// 6.1 Per Pixel Unsupervised Classification for Comparison
+var PerPixelUnsupervised = afn_Kmeans(ImageToUse,
+    numberOfUnsupervisedClusters, defaultStudyArea,
+    nativeScaleOfImage);
+Map.addLayer(PerPixelUnsupervised.select('unsupervisedClass')
+    .randomVisualizer(), {}, '6.1 Per-Pixel Unsupervised', true, 0
+);
+print('6.1b Per-Pixel Unsupervised Results:', PerPixelUnsupervised);
+
+// 6.2 SNIC Unsupervised Classification for Comparison
+var bandMeansNames = bandsToUse.map(afn_addMeanToBandName);
+//print('6.2 band mean names returned by segmentation', bandMeansNames);
+var meanSegments = SNIC_MultiBandedResults.select(bandMeansNames);
+var SegmentUnsupervised = afn_Kmeans(meanSegments,
+    numberOfUnsupervisedClusters, defaultStudyArea,
+    nativeScaleOfImage)
+    .set({'mission': originalImage.get('mission'),
+      'date': originalImage.get('date')});
+Map.addLayer(SegmentUnsupervised.randomVisualizer(), {},
+    '6.3 SNIC Clusters Unsupervised', true, 0);
+print('6.3b Per-Segment Unsupervised Results:', SegmentUnsupervised);
+
+////////////////////////////////////////////////////////////
+// 7. Zoom if requested
+////////////////////////////////////////////////////////////
+if (centerObjectYN === true) {
+    Map.centerObject(zoomArea, 10);
+}
+
+// Set the export parameters
+var exportParams = {
+  driveFolder: 'Superior_kmean',
+  crs: 'EPSG:4326',
+  scale: 30,
+  region: aoi
+};
+
+// Export the image to Google Drive
+Export.image.toDrive({
+  image: SegmentUnsupervised,
+  description: originalImage.get('mission').getInfo() + '_' + originalImage.get('date').getInfo() + '_SNIC_kmeans',
+  folder: exportParams.driveFolder,
+  crs: exportParams.crs,
+  scale: exportParams.scale,
+  region: exportParams.region
+});

--- a/preliminary_kmeans/GEE_prelim_kmeans.js
+++ b/preliminary_kmeans/GEE_prelim_kmeans.js
@@ -271,6 +271,7 @@ var meanSegments = SNIC_MultiBandedResults.select(bandMeansNames);
 var SegmentUnsupervised = afn_Kmeans(meanSegments,
     numberOfUnsupervisedClusters, defaultStudyArea,
     nativeScaleOfImage)
+    .select('unsupervisedClass').add(1).int8()
     .set({'mission': originalImage.get('mission'),
       'date': originalImage.get('date')});
 Map.addLayer(SegmentUnsupervised.randomVisualizer(), {},

--- a/preliminary_kmeans/StackingGeoTiffsFramework.Rmd
+++ b/preliminary_kmeans/StackingGeoTiffsFramework.Rmd
@@ -1,0 +1,78 @@
+---
+title: "Stacking GeoTiffs"
+author: "B Steele"
+date: "2023-04-07"
+output: html_document
+---
+
+```{r}
+# setup python venv
+source('preliminary_kmeans/pySetup.R')
+```
+
+```{python}
+#load modules
+import xarray as xr
+import os
+import rasterio
+import rioxarray as rxr
+from scipy import ndimage as ndi
+
+
+# point to directories
+data_dir = 'data/prelim_kmeans/unified_classes/'
+```
+
+# Purpose
+
+This is a framework script to stack multiple geotiffs into netCDF files for the Superior Plume-Bloom project.
+
+# Pre-work
+
+List files, prep nc file, and write functions
+
+```{python}
+
+# list all files in the directory
+files = os.listdir(data_dir)
+files = [string for string in files if string.startswith('LAND')]
+
+# create an empty xarray dataset to store the stacked data
+nc = xr.Dataset()
+
+```
+
+And now stack the files
+
+```{python}
+# loop through the GeoTiffs and add them to the dataset
+for i, geotiff_file in enumerate(files):
+  #get file info
+  file_strings = geotiff_file.split('_')
+  date = file_strings[2]
+  mission = 'Landsat '+ file_strings[1]
+  
+  # open the GeoTiff with rasterio
+  data = rxr.open_rasterio(os.path.join(data_dir, geotiff_file))
+  transform = rasterio.open(os.path.join(data_dir, geotiff_file)).transform
+  
+  # create an xarray data array and add it to the dataset, define coords
+  data_array = xr.DataArray(data,
+    dims=('band', 'y', 'x'), 
+    coords={'band': range(data.shape[0]), 'y': data.y, 'x': data.x})
+  
+  data_array.attrs['date'] = date
+  data_array.attrs['mission'] = mission
+  
+  nc[date] = data_array
+
+```
+
+# Save the netCDF
+
+```{python}
+
+# save the dataset to a netCDF file
+nc.to_netcdf(os.path.join('data/prelim_kmeans/nc/', 'example_stack.nc'))
+
+```

--- a/preliminary_kmeans/pySetup.R
+++ b/preliminary_kmeans/pySetup.R
@@ -1,0 +1,21 @@
+# a verbose version of this script exists in the pySetup.Rmd file
+
+library('reticulate')
+
+try(install_miniconda())
+py_install(c('xarray', 'rasterio', 'pandas', 'rioxarray'))
+
+#grab your current WD
+dir = getwd()
+
+#create a conda environment named 'apienv' with the packages you need
+conda_create(envname = file.path(dir, 'env'),
+             packages = c('xarray', 'pandas', 'rasterio', 'rioxarray'))
+Sys.setenv(RETICULATE_PYTHON = file.path(dir, 'env/bin/python/'))
+use_condaenv(file.path(dir, "env/"))
+
+#print the configuration
+py_config()
+
+#check install
+py_install(packages = c('xarray', 'pandas', 'rasterio', 'rioxarray'), envname = file.path(dir, 'env/'))


### PR DESCRIPTION
Heya!

As promised, here is the script to create prelim k-means rasters -- the GEE output and the reclassified/unified class images are in the Drive folder (`Superior Plume-Bloom Project/preliminary_rasters`). There's a readme file in there that should provide plenty of background, but if you have questions,  just ask!

### Notes:
- I chose a suite of images from each mission for a single year that had ~ monthly images. These images were those with low cloud cover, giving pretty complete coverage of the area. If you need more/different/mixed mission years, let me know!
- the final output from us will likely mask out clouds like are masked in the unified class images - whether that happens via the k-means or via QA_PIXEL, that is TBD. This method masks land, clouds, and saturated pixels before we do a k-means as to not classify land/clouds in the images I'm sharing. 
- I didn't apply the SNIC/k-means between images, I classified each image independently. Since the classes don't talk to each other between images, I ended up manually viewing them (because often 4 classes were too many) and making a list of what I would have labeled them. See the README file in the Drive folder. 

### Asks from you:
- Feedback about .tif files as output format would be helpful before we move forward on #22.
- Feedback about missing data/LS7 striping and how that plays with your ability to use the data helfpul too. In an ideal world, we don't gap-fill the rasters, but I also acknowledge that we may need to do that for you to have consistent data.

### Progress
This PR closes #21 and is progress on #22. 

I'm going to circle back to the Superior shapefile, validation scenes, and eePlumB scripts now! :)